### PR TITLE
Добавляем анимацию блоков

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -286,7 +286,7 @@
               <p>&laquo;Соня&raquo; может отвечать только&nbsp;Да или Нет</p>
             </li>
           </ol>
-          <a href="#game" class="rules__link btn">Погнали!</a>
+          <a href="#game" class="rules__link rules__link--hidden btn">Погнали!</a>
         </div>
       </div>
       <div class="screen__disclaimer">

--- a/source/js/modules/full-page-scroll.js
+++ b/source/js/modules/full-page-scroll.js
@@ -23,7 +23,7 @@ export default class FullPageScroll {
     const currentPosition = this.activeScreen;
     this.reCalculateActiveScreenPosition(evt.deltaY);
     if (currentPosition !== this.activeScreen) {
-      this.changePageDisplay();
+      window.location.hash = this.screenElements[this.activeScreen].id;
     }
   }
 

--- a/source/js/modules/rules.js
+++ b/source/js/modules/rules.js
@@ -1,0 +1,17 @@
+export default () => {
+  const screenRulesElement = document.querySelector(`.screen--rules`);
+  const ruleElements = screenRulesElement.querySelectorAll(`.rules__item`);
+  const ruleLinkElement = screenRulesElement.querySelector(`.rules__link`);
+  const lastRuleElement = Array.from(ruleElements).pop();
+  lastRuleElement.addEventListener(`animationend`, (event) => {
+    if (event.animationName === `show-round`) {
+      ruleLinkElement.classList.remove(`rules__link--hidden`);
+    }
+  });
+  window.addEventListener(`hashchange`, (event) => {
+    const oldHash = event.oldURL.split(`#`).pop();
+    if (oldHash === `rules`) {
+      ruleLinkElement.classList.add(`rules__link--hidden`);
+    }
+  });
+};

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -8,6 +8,7 @@ import chat from './modules/chat.js';
 import result from './modules/result.js';
 import form from './modules/form.js';
 import social from './modules/social.js';
+import rules from './modules/rules.js';
 import FullPageScroll from './modules/full-page-scroll';
 
 // init modules
@@ -20,6 +21,7 @@ chat();
 result();
 form();
 social();
+rules();
 
 const fullPageScroll = new FullPageScroll();
 fullPageScroll.init();

--- a/source/scss/blocks/btn.scss
+++ b/source/scss/blocks/btn.scss
@@ -1,6 +1,8 @@
 .btn {
   @include btn-reset;
   position: relative;
+  flex-grow: 0;
+  flex-shrink: 1;
   padding: 1.5rem 2.9rem;
   text-transform: uppercase;
   text-align: center;
@@ -29,7 +31,9 @@
   }
 
   &::before {
-    @include center;
+    position: absolute;
+    top: 0;
+    right: 0;
     content: "";
     width: 100%;
     height: 100%;

--- a/source/scss/blocks/rules.scss
+++ b/source/scss/blocks/rules.scss
@@ -60,6 +60,19 @@
   font-size: 2.4rem;
   line-height: 1.2;
 
+  opacity: 0;
+  transform: translateY(30px);
+
+  transition-property: opacity, transform;
+
+  .loaded .active & {
+    opacity: 1;
+    transform: translateY(0);
+
+    transition-duration: 500ms;
+    transition-delay: 700ms;
+  }
+
   @media (min-width: $stop-scaling) {
     margin-left: 58px;
     max-width: 960px;
@@ -119,8 +132,8 @@
 
 .rules__item {
   position: relative;
-  margin: 0 0 6.2rem;
-  padding-top: 0.6rem;
+  margin: 0 0 5.7rem;
+  padding-top: 1.1rem;
   padding-left: 6.5rem;
   break-inside: avoid;
 
@@ -145,20 +158,45 @@
   }
 
   &::before {
+    content: "";
+    background-color: $c-purple;
+    border-radius: 50%;
+
+    .loaded .active & {
+      animation-name: show-round;
+      animation-duration: 340ms;
+      animation-fill-mode: both;
+      animation-timing-function: cubic-bezier(0.28, 0.41, 0, 1);
+    }
+  }
+
+
+  &::after {
     content: counter(li);
     counter-increment: li;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 4.5rem;
-    height: 4.5rem;
     font-family: $font-alt;
     font-weight: 400;
     font-size: 2.4rem;
-    background-color: $c-purple;
-    border-radius: 50%;
     line-height: 5rem;
     text-align: center;
+    opacity: 0;
+
+    .loaded .active & {
+      opacity: 1;
+
+      transition-property: opacity;
+      transition-duration: 200ms;
+      transition-timing-function: cubic-bezier(0.28, 0.41, 0, 1);
+    }
+  }
+
+  &::before,
+  &::after {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    width: 4.5rem;
+    height: 4.5rem;
 
     @media (max-width: $tablet) and (orientation: portrait) {
       top: 1rem;
@@ -180,8 +218,35 @@
   p {
     margin: 0;
 
+    opacity: 0;
+    transform: translateX(30px);
+
+    .loaded .active & {
+      opacity: 1;
+      transform: translateX(0);
+
+      transition-property: opacity, transform;
+      transition-duration: 400ms, 330ms;
+    }
+
     @media (max-width: $tablet) and (orientation: portrait) {
       min-height: calc(1.4rem * 2.2);
+    }
+  }
+}
+
+@for $i from 1 through 4 {
+  .loaded .active .rules__item:nth-of-type(#{$i}) {
+    &::before {
+      animation-delay: 1100ms + 200ms * ($i - 1);
+    }
+
+    & p {
+      transition-delay: 1235ms + 200ms * ($i - 1), 1305ms + 200ms * ($i - 1);
+    }
+
+    &::after {
+      transition-delay: 1200ms + 200ms * ($i - 1);
     }
   }
 }
@@ -190,6 +255,30 @@
   position: absolute;
   bottom: 6rem;
   right: 5.6rem;
+
+  transition-property: color;
+  transition-timing-function: cubic-bezier(0.28, 0.41, 0, 1);
+
+  color: $c-dark;
+  transition-delay: 200ms;
+  transition-duration: 200ms;
+
+  &--hidden {
+    color: transparent;
+  }
+
+  &::before {
+    opacity: 1;
+
+    transition-property: opacity, width;
+    transition-duration: 0ms, 400ms;
+    transition-timing-function: cubic-bezier(0.28, 0.41, 0, 1);
+  }
+
+  &--hidden::before {
+    width: 33%;
+    opacity: 0;
+  }
 
   @media (min-width: $stop-scaling) {
     bottom: 60px;
@@ -209,5 +298,17 @@
   @media (max-width: $mobile) and (orientation: landscape) {
     bottom: 2rem;
     right: 1.5rem;
+  }
+}
+
+@keyframes show-round {
+  0% {
+    transform: scale(0.01);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
   }
 }


### PR DESCRIPTION
- добавлена анимационное правило `show-round` позволяющая отобразить псевдоэлементы класса `rules__item`;
- добавлен слушатель завершения анимации на последний элемент `rules__item`, для отображения кнопки после завершения всей анимации на псевдоэлементах (без учета переходов текста на `rules__item`);
- доработан механизм переключения страниц, для корректного отображения кнопки после повторного открытия экрана `rules`.

PS: вначале хотел сделать анимацию после завершения перехода для появления текста на последнем `rules__item`, но анимация получалось рваной и решил реализовать появление кнопки немного в нахлёст с появлением последнего пункта, но формально кнопка начинается появляться после завершения анимации (смотреть на `.rules__item::before`)

---
:mortar_board: [Добавляем анимацию блоков](https://up.htmlacademy.ru/animation/1/user/300063/tasks/6)

:boom: https://htmlacademy-animation.github.io/300063-magic-vacation-1/4/